### PR TITLE
플레이어의 초당 최대 TabComplete 요청을 제한

### DIFF
--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/handler/CommandAnnotationHandler.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/handler/CommandAnnotationHandler.kt
@@ -14,6 +14,7 @@ import kr.hqservice.framework.command.registry.CommandRegistry
 import kr.hqservice.framework.global.core.component.Qualifier
 import kr.hqservice.framework.global.core.component.handler.AnnotationHandler
 import kr.hqservice.framework.global.core.component.handler.HQAnnotationHandler
+import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.command.CommandMap
 import org.bukkit.command.CommandSender

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/handler/CommandTabCompletionHandler.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/handler/CommandTabCompletionHandler.kt
@@ -1,6 +1,7 @@
 package kr.hqservice.framework.command.handler
 
 import kr.hqservice.framework.command.handler.wrapper.TabCompleteEventWrapper
+import kr.hqservice.framework.command.registry.TabCompleteRateLimitRegistry
 import kr.hqservice.framework.global.core.component.Bean
 import org.bukkit.event.Event
 import org.bukkit.event.EventPriority
@@ -8,7 +9,9 @@ import org.bukkit.event.Listener
 import org.bukkit.plugin.Plugin
 
 @Bean
-class CommandTabCompletionHandler {
+class CommandTabCompletionHandler(
+    private val tabCompleteRateLimitRegistry: TabCompleteRateLimitRegistry,
+) {
     companion object {
         private val handlerMap = mutableMapOf<String, CommandAnnotationHandler.HQBukkitCommand>()
         internal fun findHQCommand(command: String): CommandAnnotationHandler.HQBukkitCommand? {
@@ -27,7 +30,7 @@ class CommandTabCompletionHandler {
 
         plugin.server.pluginManager.apply {
             val eventClass = Class.forName("com.destroystokyo.paper.event.server.AsyncTabCompleteEvent") as Class<Event>
-            val eventWrapper = TabCompleteEventWrapper(eventClass.kotlin)
+            val eventWrapper = TabCompleteEventWrapper(tabCompleteRateLimitRegistry, eventClass.kotlin)
             registerEvent(eventClass, object : Listener {}, EventPriority.LOWEST, { _, event ->
                 eventWrapper.execute(event)
             }, plugin, true)

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/handler/wrapper/TabCompleteEventWrapper.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/handler/wrapper/TabCompleteEventWrapper.kt
@@ -36,7 +36,7 @@ class TabCompleteEventWrapper(
         val sender = sender.call(event) as CommandSender
 
         val location = location.call(event) as? Location
-        val completion = if(sender is Player && !requestTabComplete(sender.uniqueId)) null else findHQCommand(command)?.hqTabComplete(
+        val completion = if(sender is Player && !sender.isTabCompletable()) null else findHQCommand(command)?.hqTabComplete(
             sender, command,
             if (args.isNotEmpty()) args.subList(1, args.size).toTypedArray() else arrayOf(""), location
         )
@@ -47,5 +47,5 @@ class TabCompleteEventWrapper(
         }
     }
 
-    private fun requestTabComplete(playerUniqueId: UUID) = tabCompleteRateLimitRegistry.requestTabComplete(playerUniqueId)
+    private fun Player.isTabCompletable() = tabCompleteRateLimitRegistry.isTabCompletable(this.uniqueId)
 }

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/registry/TabCompleteRateLimitRegistry.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/registry/TabCompleteRateLimitRegistry.kt
@@ -3,7 +3,7 @@ package kr.hqservice.framework.command.registry
 import java.util.*
 
 interface TabCompleteRateLimitRegistry {
-    fun requestTabComplete(playerUniqueId: UUID): Boolean
 
-    fun get(playerUniqueId: UUID): Int
+    fun isTabCompletable(playerUniqueId: UUID): Boolean
+
 }

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/registry/TabCompleteRateLimitRegistry.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/registry/TabCompleteRateLimitRegistry.kt
@@ -1,0 +1,9 @@
+package kr.hqservice.framework.command.registry
+
+import java.util.*
+
+interface TabCompleteRateLimitRegistry {
+    fun requestTabComplete(playerUniqueId: UUID): Boolean
+
+    fun get(playerUniqueId: UUID): Int
+}

--- a/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/registry/impl/TabCompleteRateLimitRegistryImpl.kt
+++ b/modules/bukkit-command/src/main/kotlin/kr/hqservice/framework/command/registry/impl/TabCompleteRateLimitRegistryImpl.kt
@@ -1,0 +1,30 @@
+package kr.hqservice.framework.command.registry.impl
+
+import kr.hqservice.framework.command.registry.TabCompleteRateLimitRegistry
+import kr.hqservice.framework.global.core.component.Bean
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+
+@Bean
+class TabCompleteRateLimitRegistryImpl : TabCompleteRateLimitRegistry {
+    private val tabCompleteRateLimitRegistry: MutableMap<UUID, Pair<Long, Int>> = ConcurrentHashMap()
+
+    override fun requestTabComplete(playerUniqueId: UUID): Boolean {
+        if(!tabCompleteRateLimitRegistry.containsKey(playerUniqueId)) {
+            tabCompleteRateLimitRegistry[playerUniqueId] = System.currentTimeMillis() to 1
+            return true
+        }
+
+        val pair = tabCompleteRateLimitRegistry[playerUniqueId]!!
+        if(System.currentTimeMillis() - pair.first > 1000) {
+            tabCompleteRateLimitRegistry[playerUniqueId] = System.currentTimeMillis() to 1
+            return true
+        }
+        tabCompleteRateLimitRegistry[playerUniqueId] = pair.first to pair.second + 1
+        return pair.second + 1 < 20
+    }
+
+    override fun get(playerUniqueId: UUID): Int {
+        return tabCompleteRateLimitRegistry[playerUniqueId]?.second ?: 0
+    }
+}

--- a/modules/bukkit-database/src/test/kotlin/kr/hqservice/framework/database/test/Test.kt
+++ b/modules/bukkit-database/src/test/kotlin/kr/hqservice/framework/database/test/Test.kt
@@ -1,4 +1,0 @@
-package kr.hqservice.framework.database.test
-
-import org.junit.jupiter.api.Test
-

--- a/modules/bukkit-database/src/test/kotlin/kr/hqservice/framework/database/test/Test.kt
+++ b/modules/bukkit-database/src/test/kotlin/kr/hqservice/framework/database/test/Test.kt
@@ -1,0 +1,4 @@
+package kr.hqservice.framework.database.test
+
+import org.junit.jupiter.api.Test
+

--- a/modules/bukkit-dist/src/main/resources/config.yml
+++ b/modules/bukkit-dist/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-config-version: 1
+config-version: 1.1
 
 lang: ko_kr
 
@@ -41,5 +41,8 @@ scheduler:
     misfire-threshold: 1100
     # https://stackoverflow.com/questions/14953297/recomended-value-for-org-quartz-jobstore-clustercheckininterval
     cluster-checkin-interval: 2000
+command:
+  tab-complete:
+    limit-per-second: 20
 
 forge-support: false


### PR DESCRIPTION
### TabComplete
* * *
플레이어가 일정 시간 내에 다량의 Tab Complete 요청을 할 시 **CommandArgumentProvider#getTabComplete()** 로직을 수행하지 않고 비어있는 문자 배열을 반환합니다.

**[+]**
config.yml에서 플레이어의 초당 최대 Tab Complete 요청 횟수를 설정할 수 있습니다.
```
command:
  tab-complete:
    limit-per-second: 20
```

TabCompleteRateLimitRegistryImpl 에서 플레이어가 Tab Complete 요청이 가능한지 판별하는 _requestTabComplete_ 함수의 이름을 _isTabCompletable_ 로 변경했습니다.
TabCompleteRateLimitRegistryImpl 에 있던 _get_ 함수는 사용되지 않아서 삭제했습니다.

config.yml의 config-version 이 1에서 1.1로 업데이트되었습니다.