### PR TITLE
feat: getTag 1.18.2 nms 핸들러 추가

### DIFF
--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/Version.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/Version.kt
@@ -18,6 +18,7 @@ enum class Version {
     V_16,
     V_17,
     V_18,
+    V_18_2,
     V_19,
     V_19_1,
     V_19_3,

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/item/NmsItemStackWrapper.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/item/NmsItemStackWrapper.kt
@@ -21,6 +21,7 @@ class NmsItemStackWrapper(
         nmsItemStackClass, "getTag",
         Version.V_15.handle("o"),
         Version.V_17.handle("s"),
+        Version.V_18_2.handle("t"),
         Version.V_19.handle("u"),
         Version.V_20.handle("v"),
         Version.V_20_FORGE.handle("m_41783_")


### PR DESCRIPTION
```kotlin
val item = player.inventory.itemInMainHand
item.nms {
    tag {
        setString("test", "하이")
        setInt("test2", 2)
    }
}
player.sendMessage("tag: ${item.getNmsItemStack().getTag().getString("test")}, ${item.getNmsItemStack().getTag().getInt("test2")}")
```

![image](https://github.com/HQService/HQFramework/assets/100404990/2f61ea31-2cd5-405a-a4c0-85ba779b0622)
