### PR TITLE
feat: 1.17.1~1.20.2 nms 핸들러 추가 (with Forge)

### DIFF
--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/Version.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/Version.kt
@@ -5,7 +5,9 @@ import kr.hqservice.framework.nms.handler.VersionHandler
 import kr.hqservice.framework.nms.handler.impl.CallableVersionHandler
 import kr.hqservice.framework.nms.handler.impl.NameVersionHandler
 
-enum class Version {
+enum class Version(
+    private val forge: Boolean = false
+) {
     V_7,
     V_8,
     V_9,
@@ -27,14 +29,14 @@ enum class Version {
     V_20_2,
 
     // forge
-    V_20_FORGE;
+    V_20_FORGE(true);
 
-    fun support(version: Version, minor: Int = 0): Boolean {
-        return if (minor != 0) try {
+    fun support(version: Version, minor: Int = 0, forge: Boolean): Boolean {
+        return (if (minor != 0) try {
             ordinal <= Version.valueOf("${version.name}_$minor").ordinal
         } catch (_: Exception) {
             ordinal <= version.ordinal
-        } else ordinal <= version.ordinal
+        } else ordinal <= version.ordinal) && forge == this.forge
     }
 
     fun handle(name: String, changedName: Boolean = false): VersionHandler {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/Version.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/Version.kt
@@ -28,19 +28,12 @@ enum class Version {
     // forge
     V_20_FORGE;
 
-    fun support(version: Version, minor: Int = 0, forgeSupport: Boolean = false): Boolean {
+    fun support(version: Version, minor: Int = 0): Boolean {
         return if (minor != 0) try {
-            support(Version.valueOf("${version.name}_$minor"), forgeSupport = forgeSupport)
+            ordinal <= Version.valueOf("${version.name}_$minor").ordinal
         } catch (_: Exception) {
-            support(version, forgeSupport = forgeSupport)
-        } else {
-            val ver = if (forgeSupport) try {
-                Version.valueOf(version.name + "_FORGE")
-            } catch (_: Exception) {
-                version
-            } else version
-            ordinal <= ver.ordinal
-        }
+            ordinal <= version.ordinal
+        } else ordinal <= version.ordinal
     }
 
     fun handle(name: String, changedName: Boolean = false): VersionHandler {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/Version.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/Version.kt
@@ -6,7 +6,7 @@ import kr.hqservice.framework.nms.handler.impl.CallableVersionHandler
 import kr.hqservice.framework.nms.handler.impl.NameVersionHandler
 
 enum class Version(
-    private val forge: Boolean = false
+    private val parent: Version? = null
 ) {
     V_7,
     V_8,
@@ -29,14 +29,21 @@ enum class Version(
     V_20_2,
 
     // forge
-    V_20_FORGE(true);
+    V_17_FORGE(V_17),
+    V_19_FORGE(V_19),
+    V_20_FORGE(V_20),
+    V_20_2_FORGE(V_20_2);
 
-    fun support(version: Version, minor: Int = 0, forge: Boolean): Boolean {
-        return (if (minor != 0) try {
-            ordinal <= Version.valueOf("${version.name}_$minor").ordinal
+    fun support(version: Version, minor: Int = 0): Boolean {
+        val serverOrdinal = if (minor != 0) try {
+            Version.valueOf("${version.name}_$minor").ordinal
         } catch (_: Exception) {
-            ordinal <= version.ordinal
-        } else ordinal <= version.ordinal) && forge == this.forge
+            version.ordinal
+        } else version.ordinal
+
+        val targetOrdinal = parent?.ordinal ?: ordinal
+
+        return serverOrdinal >= targetOrdinal
     }
 
     fun handle(name: String, changedName: Boolean = false): VersionHandler {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/chat/BaseComponentService.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/chat/BaseComponentService.kt
@@ -14,40 +14,42 @@ import kotlin.reflect.KClass
 class BaseComponentService(
     reflectionWrapper: NmsReflectionWrapper
 ) : NmsService<String, BaseComponentWrapper> {
+
     private val componentClass = reflectionWrapper.getNmsClass(
         "IChatBaseComponent",
-        Version.V_15.handle("network.chat")
+        Version.V_17.handle("network.chat")
     )
     private val componentSerializerClass = reflectionWrapper.getNmsClass(
         "IChatBaseComponent\$ChatSerializer",
-        Version.V_15.handle("network.chat")
+        Version.V_17.handle("network.chat")
     )
-
-    private val serializeFromJsonFunction =
-        reflectionWrapper.getFunction(componentSerializerClass,
-            FunctionType("b", null, listOf(String::class), true),
-            Version.V_19.handleFunction("b") {
-                setParameterClasses(String::class)
-                static()
-            },
-            Version.V_20_FORGE.handleFunction("m_130701_") {
-                setParameterClasses(String::class)
-                static()
-            })
-
+    private val serializeFromJsonFunction = reflectionWrapper.getFunction(componentSerializerClass,
+        FunctionType("b", null, listOf(String::class), true),
+        Version.V_17.handleFunction("b") { // fromJsonLenient ~1.20.2
+            setParameterClasses(String::class)
+            static()
+        },
+        Version.V_17_FORGE.handleFunction("m_130714_") { // fromJsonLenient (old: m_130701_)
+            setParameterClasses(String::class)
+            static()
+        }
+    )
     private val serializeFunction = serializeFromJsonFunction
 
     override fun wrap(target: String): BaseComponentWrapper {
-        return BaseComponentWrapper(target,
+        return BaseComponentWrapper(
+            target,
             serializeFunction.call(target)
                 ?: throw UnsupportedOperationException("cannot called ChatSerializer#Serialize(String) function")
         )
     }
 
     fun wrapFromJson(json: String): BaseComponentWrapper {
-        return BaseComponentWrapper(json,
+        return BaseComponentWrapper(
+            json,
             serializeFromJsonFunction.call(json)
-                ?: throw UnsupportedOperationException("cannot called ChatSerializer#fromJson(String) function"))
+                ?: throw UnsupportedOperationException("cannot called ChatSerializer#fromJson(String) function")
+        )
     }
 
     override fun unwrap(wrapper: BaseComponentWrapper): String {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/container/NmsContainerService.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/container/NmsContainerService.kt
@@ -15,23 +15,27 @@ import kotlin.reflect.KClass
 class NmsContainerService(
     private val reflectionWrapper: NmsReflectionWrapper
 ) : NmsService<Player, ContainerWrapper> {
-    private val containerClass =
-        reflectionWrapper.getNmsClass("Container", Version.V_17.handle("world.inventory.Container", true))
-    private val activeContainerField = reflectionWrapper.getField(
-        reflectionWrapper.getNmsPlayerClass(), "activeContainer",
-        Version.V_15.handle("bx"),
+
+    private val containerClass = reflectionWrapper.getNmsClass("Container",
+        Version.V_17.handle("world.inventory.Container", true)
+    )
+    private val containerMenuField = reflectionWrapper.getField(
+        reflectionWrapper.getNmsPlayerClass(), "containerMenu",
+        Version.V_17.handle("bx"),
         Version.V_17.handle("bV"),
         Version.V_18.handle("bW"),
+        Version.V_18_2.handle("bV"),
         Version.V_19.handle("bU"),
         Version.V_19_4.handle("bP"),
         Version.V_20.handle("bR"),
-        Version.V_20_FORGE.handle("f_36096_")
+        Version.V_20_2.handle("bS"),
+        Version.V_17_FORGE.handle("f_36096_")
     )
 
     override fun wrap(target: Player): ContainerWrapper {
         val nmsPlayer = reflectionWrapper.getEntityPlayer(target)
-        val activeContainer = activeContainerField.call(nmsPlayer) ?: throw UnsupportedOperationException()
-        return ContainerWrapperImpl(activeContainer, reflectionWrapper, containerClass)
+        val containerMenu = containerMenuField.call(nmsPlayer) ?: throw UnsupportedOperationException()
+        return ContainerWrapperImpl(containerMenu, reflectionWrapper, containerClass)
     }
 
     override fun getWrapper(nmsInstance: Any): ContainerWrapper {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/entity/NmsArmorStandService.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/entity/NmsArmorStandService.kt
@@ -20,41 +20,54 @@ class NmsArmorStandService(
     @Qualifier("vector3f") private val vector3fService: NmsService<Triple<Float, Float, Float>, Vector3fWrapper>,
     @Qualifier("nms.world") private val worldService: NmsService<World, WorldWrapper>,
 ) : NmsEntityService<NmsArmorStandWrapper> {
+
     private val armorStandClass = reflectionWrapper.getNmsClass(
         "EntityArmorStand",
-        Version.V_15.handle("world.entity.decoration")
+        Version.V_17.handle("world.entity.decoration")
     )
 
     private val armorStandConstructor = armorStandClass.java.getConstructor(
         worldService.getTargetClass().java, Double::class.java, Double::class.java, Double::class.java
     )
 
-    private val setHeadPoseFunction =
-        reflectionWrapper.getFunction(armorStandClass, "setHeadPose", listOf(vector3fService.getTargetClass()),
-            Version.V_15.handleFunction("a") { setParameterClasses(vector3fService.getTargetClass()) },
-            Version.V_20_FORGE.handleFunction("m_31597_") { setParameterClasses(vector3fService.getTargetClass()) }
-        )
+    private val setHeadPoseFunction = reflectionWrapper.getFunction(armorStandClass, "setHeadPose", listOf(vector3fService.getTargetClass()),
+        Version.V_17.handleFunction("a") { setParameterClasses(vector3fService.getTargetClass()) },
+        Version.V_17_FORGE.handleFunction("m_31597_") { setParameterClasses(vector3fService.getTargetClass()) }
+    )
 
     private val getHeadPoseFunction = reflectionWrapper.getFunction(
         armorStandClass, "getHeadPose",
-        Version.V_15.handleFunction("r"),
+        Version.V_17.handleFunction("r"),
         Version.V_17.handleFunction("v"),
-        Version.V_19.handleFunction("u"),
+        Version.V_18.handleFunction("u"),
         Version.V_19_4.handleFunction("x"),
-        Version.V_20_FORGE.handleFunction("m_31680_")
+        Version.V_20_2.handleFunction("z"),
+        Version.V_17_FORGE.handleFunction("m_31680_")
     )
 
     private val setSmallFunction = reflectionWrapper.getFunction(armorStandClass, "setSmall", listOf(Boolean::class),
-        Version.V_15.handleFunction("n") { setParameterClasses(Boolean::class) },
+        Version.V_17.handleFunction("n") { setParameterClasses(Boolean::class) },
         Version.V_17.handleFunction("a") { setParameterClasses(Boolean::class) },
         Version.V_19_4.handleFunction("t") { setParameterClasses(Boolean::class) },
-        Version.V_20_FORGE.handleFunction("m_31603_") { setParameterClasses(Boolean::class) }
+        Version.V_17_FORGE.handleFunction("m_31603_") { setParameterClasses(Boolean::class) }
     )
 
     private val setMarkerFunction = reflectionWrapper.getFunction(armorStandClass, "setMarker", listOf(Boolean::class),
         Version.V_17.handleFunction("t") { setParameterClasses(Boolean::class) },
         Version.V_19_4.handleFunction("u") { setParameterClasses(Boolean::class) },
-        Version.V_20_FORGE.handleFunction("m_31681_") { setParameterClasses(Boolean::class) })
+        Version.V_17_FORGE.handleFunction("m_31681_") { setParameterClasses(Boolean::class) }
+    )
+
+    private val setShowArmsFunction = reflectionWrapper.getFunction(armorStandClass, "setShowArms", listOf(Boolean::class),
+        Version.V_17.handleFunction("r") { setParameterClasses(Boolean::class) },
+        Version.V_19_4.handleFunction("a") { setParameterClasses(Boolean::class) },
+        Version.V_17_FORGE.handleFunction("m_31675_") { setParameterClasses(Boolean::class) }
+    )
+
+    private val setNoBasePlateFunction = reflectionWrapper.getFunction(armorStandClass, "setNoBasePlate", listOf(Boolean::class),
+        Version.V_17.handleFunction("s") { setParameterClasses(Boolean::class) },
+        Version.V_17_FORGE.handleFunction("m_31678_") { setParameterClasses(Boolean::class) }
+    )
 
     override fun wrap(target: Location): NmsArmorStandWrapper {
         val bukkitWorld = target.world ?: throw NullPointerException("world is null")
@@ -92,5 +105,13 @@ class NmsArmorStandService(
 
     internal fun setMarker(wrapper: NmsArmorStandWrapper, marker: Boolean) {
         setMarkerFunction.call(wrapper.getUnwrappedInstance(), marker)
+    }
+
+    internal fun setArms(wrapper: NmsArmorStandWrapper, arms: Boolean) {
+        setShowArmsFunction.call(wrapper.getUnwrappedInstance(), arms)
+    }
+
+    internal fun setBasePlate(wrapper: NmsArmorStandWrapper, basePlate: Boolean) {
+        setNoBasePlateFunction.call(wrapper.getUnwrappedInstance(), !basePlate)
     }
 }

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/item/NmsItemService.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/item/NmsItemService.kt
@@ -17,14 +17,16 @@ class NmsItemService(
     private val reflectionWrapper: NmsReflectionWrapper,
     private val languageRegistry: LanguageRegistry,
 ) : NmsService<NmsItemStackWrapper, NmsItemWrapper> {
-    private val nmsItemStackClass = reflectionWrapper.getNmsClass("ItemStack", Version.V_15.handle("world.item"))
-    private val nmsItemClass = reflectionWrapper.getNmsClass("Item", Version.V_15.handle("world.item"))
+
+    private val nmsItemStackClass = reflectionWrapper.getNmsClass("ItemStack", Version.V_17.handle("world.item"))
+    private val nmsItemClass = reflectionWrapper.getNmsClass("Item", Version.V_17.handle("world.item"))
+
     private val getItemFunction = reflectionWrapper.getFunction(
         nmsItemStackClass, "getItem",
-        Version.V_15.handle("b"),
+        Version.V_17.handle("b"),
         Version.V_17.handle("c"),
         Version.V_20.handle("d"),
-        Version.V_20_FORGE.handle("m_41720_")
+        Version.V_17_FORGE.handle("m_41720_"), // ~1.20.2
     )
 
     override fun wrap(target: NmsItemStackWrapper): NmsItemWrapper {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/item/NmsItemStackService.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/item/NmsItemStackService.kt
@@ -20,7 +20,7 @@ class NmsItemStackService(
     @Qualifier("item") private val itemService: NmsService<NmsItemStackWrapper, NmsItemWrapper>,
 ) : NmsService<ItemStack, NmsItemStackWrapper> {
     private val craftItemStackClass = reflectionWrapper.getCraftBukkitClass("inventory.CraftItemStack")
-    private val nmsItemStackClass = reflectionWrapper.getNmsClass("ItemStack", Version.V_15.handle("world.item"))
+    private val nmsItemStackClass = reflectionWrapper.getNmsClass("ItemStack", Version.V_17.handle("world.item"))
 
     private val asNmsCopyFunction = reflectionWrapper.getStaticFunction(
         craftItemStackClass,

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/item/NmsNBTTagCompoundService.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/item/NmsNBTTagCompoundService.kt
@@ -16,7 +16,7 @@ class NmsNBTTagCompoundService(
 ) : NmsService<Any?, NmsNBTTagCompoundWrapper> {
     private val nbtTagClass = reflectionWrapper.getNmsClass(
         "NBTTagCompound",
-        Version.V_15.handle("nbt")
+        Version.V_17.handle("nbt")
     )
 
     override fun wrap(target: Any?): NmsNBTTagCompoundWrapper {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/math/Vector3fService.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/math/Vector3fService.kt
@@ -15,7 +15,7 @@ class Vector3fService(
 ) : NmsService<Triple<Float, Float, Float>, Vector3fWrapper> {
     private val vector3fClass = reflectionWrapper.getNmsClass(
         "Vector3f",
-        Version.V_15.handle("core")
+        Version.V_17.handle("core")
     )
     private val vector3fConstructor =
         vector3fClass.java.getConstructor(Float::class.java, Float::class.java, Float::class.java)

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/world/WorldBorderService.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/world/WorldBorderService.kt
@@ -16,8 +16,10 @@ class WorldBorderService(
     reflectionWrapper: NmsReflectionWrapper,
     @Qualifier("nms.world") private val worldService: NmsService<World, WorldWrapper>
 ) : NmsService<World, WorldBorderWrapper> {
+
     private val worldBorderClass = reflectionWrapper.getNmsClass("WorldBorder",
-        Version.V_15.handle("world.level.border"))
+        Version.V_17.handle("world.level.border")
+    )
     private val worldBorderConstructor = worldBorderClass.constructors.first { it.parameters.isEmpty() }
     private val worldField = worldBorderClass.java.getField("world")
 

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/world/WorldService.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/service/world/WorldService.kt
@@ -16,11 +16,11 @@ import kotlin.reflect.cast
 class WorldService(
     reflectionWrapper: NmsReflectionWrapper
 ) : NmsService<World, WorldWrapper> {
+
     private val craftWorldClass = reflectionWrapper.getCraftBukkitClass("CraftWorld")
     private val getHandleFunction = reflectionWrapper.getFunction(craftWorldClass, "getHandle")
-    private val worldClass = reflectionWrapper.getNmsClass(
-        "World",
-        Version.V_15.handle("world.level")
+    private val worldClass = reflectionWrapper.getNmsClass("World",
+        Version.V_17.handle("world.level")
     )
 
     override fun wrap(target: World): WorldWrapper {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/util/impl/NettyInjectUtilImpl.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/util/impl/NettyInjectUtilImpl.kt
@@ -24,9 +24,9 @@ class NettyInjectUtilImpl(
 ) : NettyInjectUtil, HQSimpleComponent {
     private val listenerClass = reflectionWrapper.getNmsClass(
         "PlayerConnection",
-        Version.V_15.handle("server.network.ServerGamePacketListenerImpl", true)
+        Version.V_17.handle("server.network.ServerGamePacketListenerImpl", true)
     )
-    private val connectionClass = reflectionWrapper.getNmsClass("NetworkManager", Version.V_15.handle("network"))
+    private val connectionClass = reflectionWrapper.getNmsClass("NetworkManager", Version.V_17.handle("network"))
     private val connectionField = reflectionWrapper.getField(listenerClass, connectionClass)
     private val channelField = reflectionWrapper.getField(connectionClass, Channel::class)
 
@@ -43,21 +43,21 @@ class NettyInjectUtilImpl(
 
     override fun getServerChannels(server: Server): List<Channel> {
         val nmsServer = reflectionWrapper.getNmsServer(server)
-        val mcServerClass = reflectionWrapper.getNmsClass("MinecraftServer", Version.V_15.handle("server"))
+        val mcServerClass = reflectionWrapper.getNmsClass("MinecraftServer", Version.V_17.handle("server"))
 
         val serverConnectionListener =
-            reflectionWrapper.getNmsClass("ServerConnection", Version.V_15.handle("server.network"))
+            reflectionWrapper.getNmsClass("ServerConnection", Version.V_17.handle("server.network"))
         val listenerField = reflectionWrapper.getField(mcServerClass, serverConnectionListener)
         listenerField.isAccessible = true
         val listener = listenerField.call(nmsServer)
 
         val connectionField = reflectionWrapper.getField(serverConnectionListener, "h",
-            Version.V_15.handle("g"),
+            Version.V_17.handle("g"),
             Version.V_20_FORGE.handle("f_9704_")
         )
         connectionField.isAccessible = true
 
-        val connectionType = reflectionWrapper.getNmsClass("NetworkManager", Version.V_15.handle("network"))
+        val connectionType = reflectionWrapper.getNmsClass("NetworkManager", Version.V_17.handle("network"))
         val connections = connectionField.call(listener) as List<*>
 
         val output = LinkedList<Channel>()

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/AbstractVirtualEntity.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/AbstractVirtualEntity.kt
@@ -78,6 +78,11 @@ abstract class AbstractVirtualEntity(
         switchMetaMask()
     }
 
+    fun setGlowing(glowing: Boolean) {
+        virtualEntityClasses.setGlowing(glowing, getEntity())
+        switchMetaMask()
+    }
+
     fun setEquipmentItems(items: List<Pair<EquipmentSlot, ItemStack>>) {
         itemContainer = items.map {
             val slot =

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/classes/VirtualEntityClasses.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/classes/VirtualEntityClasses.kt
@@ -22,57 +22,58 @@ class VirtualEntityClasses(
 
     private val entityClass = reflectionWrapper.getNmsClass(
         "EntityLiving",
-        Version.V_15.handle("world.entity.Entity", true)
+        Version.V_17.handle("world.entity.Entity", true)
     )
 
     private val dataWatcherClass = reflectionWrapper.getNmsClass(
         "DataWatcher",
-        Version.V_15.handle("network.syncher")
+        Version.V_17.handle("network.syncher")
     )
 
     internal val entitySpawnPacket = reflectionWrapper.getNmsClass(
         "PacketPlayOutSpawnEntityLiving",
-        Version.V_15.handle("network.protocol.game.PacketPlayOutSpawnEntity", true)
+        Version.V_17.handle("network.protocol.game.PacketPlayOutSpawnEntity", true)
     ).java.getConstructor(entityClass.java)
 
     internal val entityDestroyPacket = reflectionWrapper.getNmsClass(
         "PacketPlayOutEntityDestroy",
-        Version.V_15.handle("network.protocol.game")
+        Version.V_17.handle("network.protocol.game")
     ).java.getConstructor(IntArray::class.java)
 
     internal val entityTeleportPacket = reflectionWrapper.getNmsClass(
         "PacketPlayOutEntityTeleport",
-        Version.V_15.handle("network.protocol.game")
+        Version.V_17.handle("network.protocol.game")
     ).java.getConstructor(entityClass.java)
 
     internal val entityEquipmentPacket =
         reflectionWrapper.getNmsClass(
             "PacketPlayOutEntityEquipment",
-            Version.V_15.handle("network.protocol.game")
+            Version.V_17.handle("network.protocol.game")
         ).java.getConstructor(Int::class.java, List::class.java)
 
     private val listMetadata = Version.V_19.support(reflectionWrapper.getVersion())
+
     private val entityMetadataPacket = if (!listMetadata) {
         reflectionWrapper.getNmsClass(
             "PacketPlayOutEntityMetadata",
-            Version.V_15.handle("network.protocol.game")
+            Version.V_17.handle("network.protocol.game")
         ).java.getConstructor(Int::class.java, dataWatcherClass.java, Boolean::class.java)
     } else {
         reflectionWrapper.getNmsClass(
             "PacketPlayOutEntityMetadata",
-            Version.V_15.handle("network.protocol.game")
+            Version.V_17.handle("network.protocol.game")
         ).java.getConstructor(Int::class.java, List::class.java)
     }
 
     private val getDataWatcherFunction = reflectionWrapper.getFunction(
-        entityClass, "getDataWatcher",
-        Version.V_15.handleFunction("V"),
+        entityClass, "getEntityData",
+        Version.V_17.handleFunction("V"),
         Version.V_17.handleFunction("ad"),
         Version.V_18.handleFunction("ai"),
         Version.V_19_3.handleFunction("al"),
         Version.V_19_4.handleFunction("aj"),
         Version.V_20_2.handleFunction("al"),
-        Version.V_20_FORGE.handleFunction("m_20088_")
+        Version.V_17_FORGE.handleFunction("m_20088_")
     )
 
     private val nonDefaultValueFunction = if (listMetadata) {
@@ -83,67 +84,61 @@ class VirtualEntityClasses(
 
     private val getIdFunction = reflectionWrapper.getFunction(
         entityClass, "getId",
-        Version.V_15.handleFunction("S"),
+        Version.V_17.handleFunction("S"),
         Version.V_17.handleFunction("Z"),
         Version.V_18.handleFunction("ae"),
         Version.V_19_3.handleFunction("ah"),
         Version.V_19_4.handleFunction("af"),
         Version.V_20_2.handleFunction("ah"),
-        Version.V_20_FORGE.handleFunction("m_19879_")
+        Version.V_17_FORGE.handleFunction("m_142049_"),
+        Version.V_19_FORGE.handleFunction("m_19879_")
     )
 
-    private val setCustomNameFunction =
-        reflectionWrapper.getFunction(entityClass, "setCustomName", listOf(componentWrapper.getTargetClass()),
-            Version.V_15.handleFunction("b") { setParameterClasses(componentWrapper.getTargetClass()) },
-            Version.V_18.handleFunction("a") { setParameterClasses(componentWrapper.getTargetClass()) },
-            Version.V_19.handleFunction("b") { setParameterClasses(componentWrapper.getTargetClass()) },
-            Version.V_20_FORGE.handleFunction("m_6593_") { setParameterClasses(componentWrapper.getTargetClass()) })
+    private val setCustomNameFunction = reflectionWrapper.getFunction(entityClass, "setCustomName", listOf(componentWrapper.getTargetClass()),
+        Version.V_17.handleFunction("b") { setParameterClasses(componentWrapper.getTargetClass()) },
+        Version.V_17.handleFunction("a") { setParameterClasses(componentWrapper.getTargetClass()) },
+        Version.V_19.handleFunction("b") { setParameterClasses(componentWrapper.getTargetClass()) },
+        Version.V_17_FORGE.handleFunction("m_6593_") { setParameterClasses(componentWrapper.getTargetClass()) }
+    )
 
-    private val setLocationFunction = reflectionWrapper.getFunction(entityClass,
-        "setLocation",
+    private val setCustomNameVisibleFunction = reflectionWrapper.getFunction(entityClass, "setCustomNameVisible", listOf(Boolean::class),
+        Version.V_17.handleFunction("m") { setParameterClasses(Boolean::class) },
+        Version.V_17.handleFunction("n") { setParameterClasses(Boolean::class) },
+        Version.V_17_FORGE.handleFunction("m_20340_") { setParameterClasses(Boolean::class) }
+    )
+
+    private val setLocationFunction = reflectionWrapper.getFunction(entityClass, "absMoveTo",
         listOf(Double::class, Double::class, Double::class, Float::class, Float::class),
-        Version.V_15.handleFunction("a") {
-            setParameterClasses(
-                Double::class,
-                Double::class,
-                Double::class,
-                Float::class,
-                Float::class
-            )
+        Version.V_17.handleFunction("a") {
+            setParameterClasses(Double::class, Double::class, Double::class, Float::class, Float::class)
         },
-        Version.V_20_FORGE.handleFunction("m_19890_") {
-            setParameterClasses(
-                Double::class,
-                Double::class,
-                Double::class,
-                Float::class,
-                Float::class
-            )
-        })
+        Version.V_17_FORGE.handleFunction("m_19890_") {
+            setParameterClasses(Double::class, Double::class, Double::class, Float::class, Float::class)
+        }
+    )
 
-    private val setCustomNameVisibleFunction =
-        reflectionWrapper.getFunction(entityClass, "setCustomNameVisible", listOf(Boolean::class),
-            Version.V_15.handleFunction("m") { setParameterClasses(Boolean::class) },
-            Version.V_18.handleFunction("n") { setParameterClasses(Boolean::class) },
-            Version.V_20_FORGE.handleFunction("m_20340_") { setParameterClasses(Boolean::class) })
+    private val setInvisibleFunction = reflectionWrapper.getFunction(entityClass, "setInvisible", listOf(Boolean::class),
+        Version.V_17.handleFunction("i") { setParameterClasses(Boolean::class) },
+        Version.V_17.handleFunction("j") { setParameterClasses(Boolean::class) },
+        Version.V_17_FORGE.handleFunction("m_6842_") { setParameterClasses(Boolean::class) }
+    )
 
-    private val setInvisibleFunction =
-        reflectionWrapper.getFunction(entityClass, "setInvisible", listOf(Boolean::class),
-            Version.V_15.handleFunction("i") { setParameterClasses(Boolean::class) },
-            Version.V_18.handleFunction("j") { setParameterClasses(Boolean::class) },
-            Version.V_20_FORGE.handleFunction("m_6842_") { setParameterClasses(Boolean::class) })
+    private val setGlowingTagFunction = reflectionWrapper.getFunction(entityClass, "setGlowingTag", listOf(Boolean::class),
+        Version.V_17.handleFunction("i") { setParameterClasses(Boolean::class) },
+        Version.V_17_FORGE.handleFunction("m_146915_") { setParameterClasses(Boolean::class) }
+    )
 
-    private val enumItemSlotClass = reflectionWrapper.getNmsClass("EnumItemSlot", Version.V_15.handle("world.entity"))
-    private val enumItemSlotValueOfFunction =
-        reflectionWrapper.getStaticFunction(enumItemSlotClass, "valueOf", listOf(String::class),
-            Version.V_15.handleFunction("a") {
-                setParameterClasses(String::class)
-                static()
-            },
-            Version.V_20_FORGE.handleFunction("m_20747_") {
-                setParameterClasses(String::class)
-                static()
-            })
+    private val enumItemSlotClass = reflectionWrapper.getNmsClass("EnumItemSlot", Version.V_17.handle("world.entity"))
+    private val enumItemSlotValueOfFunction = reflectionWrapper.getStaticFunction(enumItemSlotClass, "valueOf", listOf(String::class),
+        Version.V_17.handleFunction("a") {
+            setParameterClasses(String::class)
+            static()
+        },
+        Version.V_17_FORGE.handleFunction("m_20747_") {
+            setParameterClasses(String::class)
+            static()
+        }
+    )
 
     private val pairConstructor =
         Class.forName("com.mojang.datafixers.util.Pair").getConstructor(Any::class.java, Any::class.java)
@@ -187,6 +182,10 @@ class VirtualEntityClasses(
 
     fun setInvisible(invisible: Boolean, entity: Any) {
         setInvisibleFunction.call(entity, invisible)
+    }
+
+    fun setGlowing(glowing: Boolean, entity: Any) {
+        setGlowingTagFunction.call(entity, glowing)
     }
 
     fun getEnumItemSlot(enumItemSlot: String): Any {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/container/VirtualContainer.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/container/VirtualContainer.kt
@@ -19,14 +19,17 @@ class VirtualContainer(
     private val player: Player,
     private val title: String
 ) : Virtual, KoinComponent {
+
     private val reflectionWrapper: NmsReflectionWrapper by inject()
     private val baseComponentService: NmsService<String, BaseComponentWrapper> by inject(named("base-component"))
     private val containerService: NmsService<Player, ContainerWrapper> by inject(named("container"))
-    private val containersClass = reflectionWrapper.getNmsClass("Containers", Version.V_15.handle("world.inventory"))
 
-    private val packetClass =
-        reflectionWrapper.getNmsClass("PacketPlayOutOpenWindow", Version.V_15.handle("network.protocol.game"))
-
+    private val containersClass = reflectionWrapper.getNmsClass("Containers",
+        Version.V_17.handle("world.inventory")
+    )
+    private val packetClass = reflectionWrapper.getNmsClass("PacketPlayOutOpenWindow",
+        Version.V_17.handle("network.protocol.game")
+    )
     private val bukkitViewFunction = reflectionWrapper.getFunction(containerService.getTargetClass(), "getBukkitView")
 
     override fun createVirtualMessage(): VirtualMessage? {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/entity/VirtualArmorStand.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/entity/VirtualArmorStand.kt
@@ -40,5 +40,15 @@ class VirtualArmorStand(
         wrapper.setMarker(marker)
         switchMetaMask()
     }
+
+    fun setArms(arms: Boolean) {
+        wrapper.setArms(arms)
+        switchMetaMask()
+    }
+
+    fun setBasePlate(basePlate: Boolean) {
+        wrapper.setBasePlate(basePlate)
+        switchMetaMask()
+    }
 }
 

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/entity/inner/VirtualCamera.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/entity/inner/VirtualCamera.kt
@@ -13,12 +13,12 @@ class VirtualCamera(
     private val virtualEntity: AbstractVirtualEntity?,
     private val reflectionWrapper: NmsReflectionWrapper
 ) : Virtual {
-    private val entityClass = reflectionWrapper.getNmsClass("Entity", Version.V_15.handle("world.entity"))
+    private val entityClass = reflectionWrapper.getNmsClass("Entity", Version.V_17.handle("world.entity"))
     private val stateChangePacketClass =
-        reflectionWrapper.getNmsClass("PacketPlayOutGameStateChange", Version.V_15.handle("network.protocol.game"))
+        reflectionWrapper.getNmsClass("PacketPlayOutGameStateChange", Version.V_17.handle("network.protocol.game"))
     private val changeGameModeType = reflectionWrapper.getStaticField(stateChangePacketClass, "d").call()!!
     private val cameraPacketClass =
-        reflectionWrapper.getNmsClass("PacketPlayOutCamera", Version.V_15.handle("network.protocol.game"))
+        reflectionWrapper.getNmsClass("PacketPlayOutCamera", Version.V_17.handle("network.protocol.game"))
 
     override fun createVirtualMessage(): VirtualMessage {
         val stateChangePacket: Any

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/handler/impl/VirtualItemHandler.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/handler/impl/VirtualItemHandler.kt
@@ -1,6 +1,5 @@
 package kr.hqservice.framework.nms.virtual.handler.impl
 
-import kr.hqservice.framework.global.core.extension.print
 import kr.hqservice.framework.nms.Version
 import kr.hqservice.framework.nms.extension.callAccess
 import kr.hqservice.framework.nms.extension.getNmsItemStack
@@ -18,14 +17,16 @@ class VirtualItemHandler(
     private var filter: (Int, ItemStack) -> Boolean,
     private var item: (index: Int, itemStack: ItemStack) -> Unit
 ) : VirtualHandler {
+
     override fun getNmsSimpleNames(): List<String> {
         return listOf(/*"PacketPlayOutSetSlot", */"PacketPlayOutWindowItems", "ClientboundContainerSetContentPacket")
     }
 
     override fun checkCondition(message: Any): Boolean {
         return if (message::class.simpleName == "PacketPlayOutWindowItems" || message::class.simpleName == "ClientboundContainerSetContentPacket") {
-            val containerId = reflectionWrapper.getField(message::class, "a",
-                Version.V_20_FORGE.handle("f_131942_")
+            val containerId = reflectionWrapper.getField(message::class, "containerId",
+                Version.V_17.handle("a"),
+                Version.V_17_FORGE.handle("f_131942_")
             ).callAccess<Int>(message)
             (containerId == targetContainer)
         } else false
@@ -38,14 +39,16 @@ class VirtualItemHandler(
     override fun unregisterCondition(message: Any): Boolean {
         return when (message::class.simpleName) {
             "PacketPlayOutOpenWindow", "ClientboundOpenScreenPacket" -> {
-                val containerId = reflectionWrapper.getField(message::class, "a",
-                    Version.V_20_FORGE.handle("f_132611_")
+                val containerId = reflectionWrapper.getField(message::class, "containerId",
+                    Version.V_17.handle("a"),
+                    Version.V_17_FORGE.handle("f_132611_")
                 ).callAccess<Int>(message)
                 (containerId != targetContainer)
             }
             "PacketPlayOutCloseWindow", "ClientboundContainerClosePacket" -> {
-                val containerId = reflectionWrapper.getField(message::class, "a",
-                    Version.V_20_FORGE.handle("f_131930_")
+                val containerId = reflectionWrapper.getField(message::class, "containerId",
+                    Version.V_17.handle("a"),
+                    Version.V_17_FORGE.handle("f_131930_")
                 ).callAccess<Int>(message)
                 (containerId == targetContainer)
             }
@@ -67,7 +70,10 @@ class VirtualItemHandler(
                 }
             }*/
             "PacketPlayOutWindowItems", "ClientboundContainerSetContentPacket" -> {
-                val listField = reflectionWrapper.getField(message::class, "c", Version.V_20_FORGE.handle("f_131943_"))
+                val listField = reflectionWrapper.getField(message::class, "items",
+                    Version.V_17.handle("c"),
+                    Version.V_17_FORGE.handle("f_131943_")
+                )
                 val list = listField.callAccess<MutableList<Any>>(message)
                 list.forEachIndexed { index, any ->
                     val wrapper = itemStackService.getWrapper(any)

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/item/VirtualItem.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/item/VirtualItem.kt
@@ -26,7 +26,7 @@ class VirtualItem(
     private val itemStackService: NmsService<ItemStack, NmsItemStackWrapper> by inject(named("itemStack"))
     private val containerService: NmsService<Player, ContainerWrapper> by inject(named("container"))
     private val packetClass =
-        reflectionWrapper.getNmsClass("PacketPlayOutSetSlot", Version.V_15.handle("network.protocol.game"))
+        reflectionWrapper.getNmsClass("PacketPlayOutSetSlot", Version.V_17.handle("network.protocol.game"))
 
     override fun createVirtualMessage(): VirtualMessage {
         val container = containerService.wrap(player)

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/world/VirtualWorldBorder.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/virtual/world/VirtualWorldBorder.kt
@@ -17,21 +17,26 @@ import org.koin.core.qualifier.named
 class VirtualWorldBorder(
     world: World
 ) : Virtual, KoinComponent {
+
     private val reflectionWrapper: NmsReflectionWrapper by inject()
     private val service: NmsService<World, WorldBorderWrapper> by inject(named("nms.world.border"))
-    private val packetClass =
-        reflectionWrapper.getNmsClass("ClientboundInitializeBorderPacket", Version.V_15.handle("network.protocol.game"))
     private val borderWrapper = service.wrap(world)
-    private val extendClass = reflectionWrapper.getNmsClass(
-        "WorldBorder\$d",
-        Version.V_15.handle("world.level.border")
+
+    private val packetClass = reflectionWrapper.getNmsClass("ClientboundInitializeBorderPacket",
+        Version.V_17.handle("network.protocol.game")
     )
-    private val extendConstructor = extendClass.java.getConstructor(service.getTargetClass().java, Double::class.javaPrimitiveType).apply {
+    private val extentField = reflectionWrapper.getField(service.getTargetClass(), "extent",
+        Version.V_17.handle("k"),
+        Version.V_18.handle("l"),
+        Version.V_17_FORGE.handle("f_61914_")
+    )
+    private val extentClass = reflectionWrapper.getNmsClass("WorldBorder\$d",
+        Version.V_17.handle("world.level.border")
+    )
+    private val extentConstructor = extentClass.java.getConstructor(service.getTargetClass().java, Double::class.javaPrimitiveType).apply {
         isAccessible = true
     }
 
-    private val sizeField = reflectionWrapper.getField(service.getTargetClass(), "l",
-        Version.V_19.handle("l"))
     private var packetQueue = mutableMapOf<Int, Any>()
 
     fun setCenter(x: Double, z: Double) {
@@ -43,9 +48,9 @@ class VirtualWorldBorder(
     }
 
     fun setSize(size: Double) {
-        sizeField.setAccess(
+        extentField.setAccess(
             borderWrapper.getUnwrappedInstance(),
-            extendConstructor.newInstance(borderWrapper.getUnwrappedInstance(), size)
+            extentConstructor.newInstance(borderWrapper.getUnwrappedInstance(), size)
         )
     }
 
@@ -63,17 +68,28 @@ class VirtualWorldBorder(
         private val x: Double,
         private val z: Double
     ) {
-        private val packetClass =
-            reflectionWrapper.getNmsClass("ClientboundSetBorderCenterPacket", Version.V_15.handle("network.protocol.game"))
+
+        private val packetClass = reflectionWrapper.getNmsClass("ClientboundSetBorderCenterPacket",
+            Version.V_17.handle("network.protocol.game")
+        )
         private val constructor = packetClass.java.getConstructor(service.getTargetClass().java)
-        private val xField = reflectionWrapper.getField(service.getTargetClass(), "h",
-            Version.V_19.handle("i"))
-        private val zField = reflectionWrapper.getField(service.getTargetClass(), "i",
-            Version.V_19.handle("j"))
+
+        private val centerXField = reflectionWrapper.getField(
+            service.getTargetClass(), "centerX",
+            Version.V_17.handle("h"),
+            Version.V_18.handle("i"),
+            Version.V_17_FORGE.handle("f_61911_")
+        )
+        private val centerZField = reflectionWrapper.getField(
+            service.getTargetClass(), "centerZ",
+            Version.V_17.handle("i"),
+            Version.V_18.handle("j"),
+            Version.V_17_FORGE.handle("f_61912_")
+        )
 
         fun createPacket(): Any {
-            xField.setAccess(borderWrapper.getUnwrappedInstance(), x)
-            zField.setAccess(borderWrapper.getUnwrappedInstance(), z)
+            centerXField.setAccess(borderWrapper.getUnwrappedInstance(), x)
+            centerZField.setAccess(borderWrapper.getUnwrappedInstance(), z)
             return constructor.newInstance(borderWrapper.getUnwrappedInstance())
         }
     }
@@ -81,15 +97,22 @@ class VirtualWorldBorder(
     private inner class WorldBorderWarningBlocks(
         private val blocks: Int
     ) {
-        private val packetClass =
-            reflectionWrapper.getNmsClass("ClientboundSetBorderWarningDistancePacket", Version.V_15.handle("network.protocol.game"))
+
+        private val packetClass = reflectionWrapper.getNmsClass(
+            "ClientboundSetBorderWarningDistancePacket", Version.V_17.handle("network.protocol.game")
+        )
         private val constructor = packetClass.java.getConstructor(service.getTargetClass().java)
-        private val hField = reflectionWrapper.getField(service.getTargetClass(), "h")
+
+        private val warningBlocksField = reflectionWrapper.getField(
+            service.getTargetClass(), "warningBlocks",
+            Version.V_17.handle("g"),
+            Version.V_18.handle("h"),
+            Version.V_17_FORGE.handle("f_61910_")
+        )
 
         fun createPacket(): Any {
-            hField.setAccess(borderWrapper.getUnwrappedInstance(), blocks)
+            warningBlocksField.setAccess(borderWrapper.getUnwrappedInstance(), blocks)
             return constructor.newInstance(borderWrapper.getUnwrappedInstance())
         }
-
     }
 }

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/container/ContainerWrapperImpl.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/container/ContainerWrapperImpl.kt
@@ -11,21 +11,21 @@ class ContainerWrapperImpl(
     reflectionWrapper: NmsReflectionWrapper,
     containerClass: KClass<*>
 ) : ContainerWrapper {
-    private val windowIdField = reflectionWrapper.getField(
-        containerClass, "windowId",
-        Version.V_17.handle("j"),
-        Version.V_20_FORGE.handle("f_38840_")
-    )
 
+    private val containerIdField = reflectionWrapper.getField(
+        containerClass, "containerId",
+        Version.V_17.handle("j"),
+        Version.V_17_FORGE.handle("f_38840_")
+    )
     private val stateIdField = reflectionWrapper.getField(
-        containerClass, "q",
-        Version.V_19.handle("q"),
-        Version.V_19_1.handle("r"),
-        Version.V_20_FORGE.handle("f_182405_")
+        containerClass, "stateId",
+        Version.V_17.handle("q"),
+        Version.V_18_2.handle("r"),
+        Version.V_17_FORGE.handle("f_182405_")
     )
 
     override fun getContainerId(): Int {
-        return windowIdField.callAccess(container)
+        return containerIdField.callAccess(container)
     }
 
     override fun getStateId(): Int {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/entity/NmsArmorStandWrapper.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/entity/NmsArmorStandWrapper.kt
@@ -24,6 +24,14 @@ class NmsArmorStandWrapper(
         service.setMarker(this, marker)
     }
 
+    fun setArms(arms: Boolean) {
+        service.setArms(this, arms)
+    }
+
+    fun setBasePlate(basePlate: Boolean) {
+        service.setBasePlate(this, basePlate)
+    }
+
     override fun getUnwrappedInstance(): Any {
         return baseEntity
     }

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/item/NmsItemStackWrapper.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/item/NmsItemStackWrapper.kt
@@ -14,22 +14,23 @@ class NmsItemStackWrapper(
     private val itemService: NmsService<NmsItemStackWrapper, NmsItemWrapper>,
     private val itemStackService: NmsService<ItemStack, NmsItemStackWrapper>
 ) : NmsWrapper {
-    private val nmsItemStackClass = reflectionWrapper.getNmsClass("ItemStack", Version.V_15.handle("world.item"))
-    private val nbtTagClass = reflectionWrapper.getNmsClass("NBTTagCompound", Version.V_15.handle("nbt"))
+
+    private val nmsItemStackClass = reflectionWrapper.getNmsClass("ItemStack", Version.V_17.handle("world.item"))
+    private val nbtTagClass = reflectionWrapper.getNmsClass("NBTTagCompound", Version.V_17.handle("nbt"))
 
     private val getTagFunction = reflectionWrapper.getFunction(
         nmsItemStackClass, "getTag",
-        Version.V_15.handle("o"),
+        Version.V_17.handle("o"),
         Version.V_17.handle("s"),
         Version.V_18_2.handle("t"),
         Version.V_19.handle("u"),
         Version.V_20.handle("v"),
-        Version.V_20_FORGE.handle("m_41783_")
+        Version.V_17_FORGE.handle("m_41783_") // ~1.20.2
     )
 
     private val setTagFunction = reflectionWrapper.getFunction(nmsItemStackClass, "setTag", listOf(nbtTagClass),
-        Version.V_15.handleFunction("c") { setParameterClasses(nbtTagClass) },
-        Version.V_20_FORGE.handleFunction("m_41751_") { setParameterClasses(nbtTagClass) }
+        Version.V_17.handleFunction("c") { setParameterClasses(nbtTagClass) },
+        Version.V_17_FORGE.handleFunction("m_41751_") { setParameterClasses(nbtTagClass) }, // ~1.20.2
     )
 
     fun hasTag(): Boolean {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/item/NmsItemWrapper.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/item/NmsItemWrapper.kt
@@ -16,10 +16,11 @@ class NmsItemWrapper(
     reflectionWrapper: NmsReflectionWrapper,
     private val languageRegistry: LanguageRegistry
 ) : NmsWrapper {
-    private val getDescriptionIdFunction = reflectionWrapper
-        .getFunction(nmsItemClass, "j", listOf(nmsItemStackClass),
-            Version.V_20_FORGE.handleFunction("m_5671_") { setParameterClasses(nmsItemStackClass) }
-        )
+
+    private val getDescriptionIdFunction = reflectionWrapper.getFunction(nmsItemClass, "getDescriptionId", listOf(nmsItemStackClass),
+        Version.V_17.handleFunction("j") { setParameterClasses(nmsItemStackClass) },
+        Version.V_17_FORGE.handleFunction("m_5671_") { setParameterClasses(nmsItemStackClass) } // ~1.20.2
+    )
 
     fun getDescriptionName(): String {
         return getDescriptionIdFunction.call(nmsItem, nmsItemStackWrapper.getUnwrappedInstance()) as? String

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/item/NmsNBTTagCompoundWrapper.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/item/NmsNBTTagCompoundWrapper.kt
@@ -4,50 +4,151 @@ import kr.hqservice.framework.nms.Version
 import kr.hqservice.framework.nms.wrapper.NmsReflectionWrapper
 import kr.hqservice.framework.nms.wrapper.NmsWrapper
 import kr.hqservice.framework.nms.wrapper.getFunction
+import java.util.UUID
 
 class NmsNBTTagCompoundWrapper(
     private val nbtTag: Any,
     reflectionWrapper: NmsReflectionWrapper
 ) : NmsWrapper {
-    private val nbtTagClass = reflectionWrapper.getNmsClass("NBTTagCompound", Version.V_15.handle("nbt"))
+
+    private val nbtTagClass = reflectionWrapper.getNmsClass("NBTTagCompound", Version.V_17.handle("nbt"))
 
     private val getStringFunction = reflectionWrapper.getFunction(nbtTagClass, "getString", listOf(String::class),
-        Version.V_15.handleFunction("l") { setParameterClasses(String::class) },
-        Version.V_20_FORGE.handleFunction("m_128461_") { setParameterClasses(String::class) }
+        Version.V_17.handleFunction("l") { setParameterClasses(String::class) },
+        Version.V_17_FORGE.handleFunction("m_128461_") { setParameterClasses(String::class) } // ~1.20.2
+    )
+
+    private val getBooleanFunction = reflectionWrapper.getFunction(nbtTagClass, "getBoolean", listOf(String::class),
+        Version.V_17.handleFunction("q") { setParameterClasses(String::class) },
+        Version.V_17_FORGE.handleFunction("m_128471_") { setParameterClasses(String::class) }, // ~1.20.2
+    )
+
+    private val getUUIDFunction = reflectionWrapper.getFunction(nbtTagClass, "getUUID", listOf(String::class),
+        Version.V_17.handleFunction("a") { setParameterClasses(String::class) },
+        Version.V_17_FORGE.handleFunction("m_128342_") { setParameterClasses(String::class) }, // ~1.20.2
+    )
+
+    private val getByteFunction = reflectionWrapper.getFunction(nbtTagClass, "getByte", listOf(String::class),
+        Version.V_17.handleFunction("f") { setParameterClasses(String::class) },
+        Version.V_17_FORGE.handleFunction("m_128445_") { setParameterClasses(String::class) }, // ~1.20.2
+    )
+
+    private val getShortFunction = reflectionWrapper.getFunction(nbtTagClass, "getShort", listOf(String::class),
+        Version.V_17.handleFunction("g") { setParameterClasses(String::class) },
+        Version.V_17_FORGE.handleFunction("m_128448_") { setParameterClasses(String::class) }, // ~1.20.2
     )
 
     private val getIntFunction = reflectionWrapper.getFunction(nbtTagClass, "getInt", listOf(String::class),
-        Version.V_15.handleFunction("i") { setParameterClasses(String::class) },
+        Version.V_17.handleFunction("i") { setParameterClasses(String::class) },
         Version.V_17.handleFunction("h") { setParameterClasses(String::class) },
-        Version.V_20_FORGE.handleFunction("m_128451_") { setParameterClasses(String::class) }
+        Version.V_17_FORGE.handleFunction("m_128451_") { setParameterClasses(String::class) } // ~1.20.2
     )
 
-    private val setIntFunction = reflectionWrapper.getFunction(nbtTagClass, "setInt", listOf(String::class, Int::class),
-        Version.V_15.handleFunction("a") { setParameterClasses(String::class, Int::class) },
-        Version.V_20_FORGE.handleFunction("m_128405_") { setParameterClasses(String::class, Int::class) }
+    private val getLongFunction = reflectionWrapper.getFunction(nbtTagClass, "getLong", listOf(String::class),
+        Version.V_17.handleFunction("i") { setParameterClasses(String::class) },
+        Version.V_17_FORGE.handleFunction("m_128454_") { setParameterClasses(String::class) }, // ~1.20.2
     )
 
-    private val setStringFunction =
-        reflectionWrapper.getFunction(nbtTagClass, "setString", listOf(String::class, String::class),
-            Version.V_15.handleFunction("a") { setParameterClasses(String::class, String::class) },
-            Version.V_20_FORGE.handleFunction("m_128359_") { setParameterClasses(String::class, String::class) }
-        )
+    private val getFloatFunction = reflectionWrapper.getFunction(nbtTagClass, "getFloat", listOf(String::class),
+        Version.V_17.handleFunction("j") { setParameterClasses(String::class) },
+        Version.V_17_FORGE.handleFunction("m_128457_") { setParameterClasses(String::class) }, // ~1.20.2
+    )
+
+    private val getDoubleFunction = reflectionWrapper.getFunction(nbtTagClass, "getDouble", listOf(String::class),
+        Version.V_17.handleFunction("k") { setParameterClasses(String::class) },
+        Version.V_17_FORGE.handleFunction("m_128459_") { setParameterClasses(String::class) }, // ~1.20.2
+    )
+
+    private val getByteArrayFunction = reflectionWrapper.getFunction(nbtTagClass, "getByteArray", listOf(String::class),
+        Version.V_17.handleFunction("m") { setParameterClasses(String::class) },
+        Version.V_17_FORGE.handleFunction("m_128463_") { setParameterClasses(String::class) }, // ~1.20.2
+    )
+
+    private val getIntArrayFunction = reflectionWrapper.getFunction(nbtTagClass, "getIntArray", listOf(String::class),
+        Version.V_17.handleFunction("n") { setParameterClasses(String::class) },
+        Version.V_17_FORGE.handleFunction("m_128465_") { setParameterClasses(String::class) }, // ~1.20.2
+    )
+
+    private val getLongArrayFunction = reflectionWrapper.getFunction(nbtTagClass, "getLongArray", listOf(String::class),
+        Version.V_17.handleFunction("o") { setParameterClasses(String::class) },
+        Version.V_17_FORGE.handleFunction("m_128467_") { setParameterClasses(String::class) }, // ~1.20.2
+    )
+
+    private val setStringFunction = reflectionWrapper.getFunction(nbtTagClass, "putString", listOf(String::class, String::class),
+        Version.V_17.handleFunction("a") { setParameterClasses(String::class, String::class) },
+        Version.V_17_FORGE.handleFunction("m_128359_") { setParameterClasses(String::class, String::class) } // ~1.20.2
+    )
+
+    private val setBooleanFunction = reflectionWrapper.getFunction(nbtTagClass, "putBoolean", listOf(String::class, Boolean::class),
+        Version.V_17.handleFunction("a") { setParameterClasses(String::class, Boolean::class) },
+        Version.V_17_FORGE.handleFunction("m_128379_") { setParameterClasses(String::class, Boolean::class) } // ~1.20.2
+    )
+
+    private val setUUIDFunction = reflectionWrapper.getFunction(nbtTagClass, "putUUID", listOf(String::class, UUID::class),
+        Version.V_17.handleFunction("a") { setParameterClasses(String::class, UUID::class) },
+        Version.V_17_FORGE.handleFunction("m_128362_") { setParameterClasses(String::class, UUID::class) } // ~1.20.2
+    )
+
+    private val setByteFunction = reflectionWrapper.getFunction(nbtTagClass, "putByte", listOf(String::class, Byte::class),
+        Version.V_17.handleFunction("a") { setParameterClasses(String::class, Byte::class) },
+        Version.V_17_FORGE.handleFunction("m_128344_") { setParameterClasses(String::class, Byte::class) } // ~1.20.2
+    )
+
+    private val setShortFunction = reflectionWrapper.getFunction(nbtTagClass, "putShort", listOf(String::class, Short::class),
+        Version.V_17.handleFunction("a") { setParameterClasses(String::class, Short::class) },
+        Version.V_17_FORGE.handleFunction("m_128376_") { setParameterClasses(String::class, Short::class) } // ~1.20.2
+    )
+
+    private val setIntFunction = reflectionWrapper.getFunction(nbtTagClass, "putInt", listOf(String::class, Int::class),
+        Version.V_17.handleFunction("a") { setParameterClasses(String::class, Int::class) },
+        Version.V_17_FORGE.handleFunction("m_128405_") { setParameterClasses(String::class, Int::class) } // ~1.20.2
+    )
+
+    private val setLongFunction = reflectionWrapper.getFunction(nbtTagClass, "putLong", listOf(String::class, Long::class),
+        Version.V_17.handleFunction("a") { setParameterClasses(String::class, Long::class) },
+        Version.V_17_FORGE.handleFunction("m_128356_") { setParameterClasses(String::class, Long::class) } // ~1.20.2
+    )
+
+    private val setFloatFunction = reflectionWrapper.getFunction(nbtTagClass, "putFloat", listOf(String::class, Float::class),
+        Version.V_17.handleFunction("a") { setParameterClasses(String::class, Float::class) },
+        Version.V_17_FORGE.handleFunction("m_128350_") { setParameterClasses(String::class, Float::class) } // ~1.20.2
+    )
+
+    private val setDoubleFunction = reflectionWrapper.getFunction(nbtTagClass, "putDouble", listOf(String::class, Double::class),
+        Version.V_17.handleFunction("a") { setParameterClasses(String::class, Double::class) },
+        Version.V_17_FORGE.handleFunction("m_128347_") { setParameterClasses(String::class, Double::class) } // ~1.20.2
+    )
+
+    private val setByteArrayFunction = reflectionWrapper.getFunction(nbtTagClass, "putByteArray", listOf(String::class, ByteArray::class),
+        Version.V_17.handleFunction("a") { setParameterClasses(String::class, ByteArray::class) },
+        Version.V_17_FORGE.handleFunction("m_128382_") { setParameterClasses(String::class, ByteArray::class) } // ~1.20.2
+    )
+
+    private val setIntArrayFunction = reflectionWrapper.getFunction(nbtTagClass, "putIntArray", listOf(String::class, IntArray::class),
+        Version.V_17.handleFunction("a") { setParameterClasses(String::class, IntArray::class) },
+        Version.V_17_FORGE.handleFunction("m_128385_") { setParameterClasses(String::class, IntArray::class) } // ~1.20.2
+    )
+
+    private val setLongArrayFunction = reflectionWrapper.getFunction(nbtTagClass, "putLongArray", listOf(String::class, LongArray::class),
+        Version.V_17.handleFunction("a") { setParameterClasses(String::class, LongArray::class) },
+        Version.V_17_FORGE.handleFunction("m_128388_") { setParameterClasses(String::class, LongArray::class) } // ~1.20.2
+    )
 
     private val removeFunction = reflectionWrapper.getFunction(nbtTagClass, "remove", listOf(String::class),
-        Version.V_15.handleFunction("r") { setParameterClasses(String::class) },
-        Version.V_20_FORGE.handleFunction("m_128473_") { setParameterClasses(String::class) }
+        Version.V_17.handleFunction("r") { setParameterClasses(String::class) },
+        Version.V_17_FORGE.handleFunction("m_128473_") { setParameterClasses(String::class) } // ~1.20.2
     )
 
     private val containsFunction = reflectionWrapper.getFunction(nbtTagClass, "contains", listOf(String::class),
-        Version.V_15.handleFunction("e") { setParameterClasses(String::class) },
-        Version.V_20_FORGE.handleFunction("m_128441_") { setParameterClasses(String::class) }
+        Version.V_17.handleFunction("e") { setParameterClasses(String::class) },
+        Version.V_17_FORGE.handleFunction("m_128441_") { setParameterClasses(String::class) } // ~1.20.2
     )
 
     private val isEmptyFunction = reflectionWrapper.getFunction(
         nbtTagClass, "isEmpty",
-        Version.V_15.handleFunction("f"),
+        Version.V_17.handleFunction("f"),
         Version.V_19_3.handleFunction("g"),
-        Version.V_20_FORGE.handleFunction("m_128456_")
+        Version.V_17_FORGE.handleFunction("m_128456_") // ~1.20.2
     )
 
     fun getString(key: String, def: String = ""): String {
@@ -55,12 +156,59 @@ class NmsNBTTagCompoundWrapper(
     }
 
     fun getStringOrNull(key: String): String? {
-        return if (hasKey(key)) return getString(key)
-        else null
+        return if (hasKey(key)) return getString(key) else null
     }
 
     fun setString(key: String, value: String) {
         setStringFunction.call(nbtTag, key, value)
+    }
+
+    fun getBoolean(key: String, def: Boolean = false): Boolean {
+        return getBooleanFunction.call(nbtTag, key) as? Boolean ?: def
+    }
+
+    fun getBooleanOrNull(key: String): Boolean? {
+        return if (hasKey(key)) return getBoolean(key) else null
+    }
+
+    fun setBoolean(key: String, value: Boolean) {
+        setBooleanFunction.call(nbtTag, key, value)
+    }
+
+    fun getUUID(key: String): UUID {
+        return getUUIDFunction.call(nbtTag, key) as UUID
+    }
+
+    fun getUUIDOrNull(key: String): UUID? {
+        return if (hasKey(key)) return getUUID(key) else null
+    }
+
+    fun setUUID(key: String, value: UUID) {
+        setUUIDFunction.call(nbtTag, key, value)
+    }
+
+    fun getByte(key: String, def: Byte = 0): Byte {
+        return getByteFunction.call(nbtTag, key) as? Byte ?: def
+    }
+
+    fun getByteOrNull(key: String): Byte? {
+        return if (hasKey(key)) getByte(key) else null
+    }
+
+    fun setByte(key: String, value: Byte) {
+        setByteFunction.call(nbtTag, key, value)
+    }
+
+    fun getShort(key: String, def: Short = 0): Short {
+        return getShortFunction.call(nbtTag, key) as? Short ?: def
+    }
+
+    fun getShortOrNull(key: String): Short? {
+        return if (hasKey(key)) getShort(key) else null
+    }
+
+    fun setShort(key: String, value: Short) {
+        setShortFunction.call(nbtTag, key, value)
     }
 
     fun getInt(key: String, def: Int = 0): Int {
@@ -68,12 +216,83 @@ class NmsNBTTagCompoundWrapper(
     }
 
     fun getIntOrNull(key: String): Int? {
-        return if (hasKey(key)) getInt(key)
-        else null
+        return if (hasKey(key)) getInt(key) else null
     }
 
     fun setInt(key: String, value: Int) {
         setIntFunction.call(nbtTag, key, value)
+    }
+
+    fun getLong(key: String, def: Long = 0L): Long {
+        return getLongFunction.call(nbtTag, key) as? Long ?: def
+    }
+
+    fun getLongOrNull(key: String): Long? {
+        return if (hasKey(key)) getLong(key) else null
+    }
+
+    fun setLong(key: String, value: Long) {
+        setLongFunction.call(nbtTag, key, value)
+    }
+
+    fun getFloat(key: String, def: Float = 0f): Float {
+        return getFloatFunction.call(nbtTag, key) as? Float ?: def
+    }
+
+    fun getFloatOrNull(key: String): Float? {
+        return if (hasKey(key)) getFloat(key) else null
+    }
+
+    fun setFloat(key: String, value: Float) {
+        setFloatFunction.call(nbtTag, key, value)
+    }
+
+    fun getDouble(key: String, def: Double = 0.0): Double {
+        return getDoubleFunction.call(nbtTag, key) as? Double ?: def
+    }
+
+    fun getDoubleOrNull(key: String): Double? {
+        return if (hasKey(key)) getDouble(key) else null
+    }
+
+    fun setDouble(key: String, value: Double) {
+        setDoubleFunction.call(nbtTag, key, value)
+    }
+
+    fun getByteArray(key: String, def: ByteArray = byteArrayOf()): ByteArray {
+        return getByteArrayFunction.call(nbtTag, key) as? ByteArray ?: def
+    }
+
+    fun getByteArrayOrNull(key: String): ByteArray? {
+        return if (hasKey(key)) getByteArray(key) else null
+    }
+
+    fun setByteArray(key: String, value: ByteArray) {
+        setByteArrayFunction.call(nbtTag, key, value)
+    }
+
+    fun getIntArray(key: String, def: IntArray = intArrayOf()): IntArray {
+        return getIntArrayFunction.call(nbtTag, key) as? IntArray ?: def
+    }
+
+    fun getIntArrayOrNull(key: String): IntArray? {
+        return if (hasKey(key)) getIntArray(key) else null
+    }
+
+    fun setIntArray(key: String, value: IntArray) {
+        setIntArrayFunction.call(nbtTag, key, value)
+    }
+
+    fun getLongArray(key: String, def: LongArray = longArrayOf()): LongArray {
+        return getLongArrayFunction.call(nbtTag, key) as? LongArray ?: def
+    }
+
+    fun getLongArrayOrNull(key: String): LongArray? {
+        return if (hasKey(key)) getLongArray(key) else null
+    }
+
+    fun setLongArray(key: String, value: LongArray) {
+        setLongArrayFunction.call(nbtTag, key, value)
     }
 
     fun hasKey(key: String): Boolean {

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/math/Vector3fWrapper.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/math/Vector3fWrapper.kt
@@ -11,9 +11,21 @@ class Vector3fWrapper(
     targetClass: KClass<*>,
     reflectionWrapper: NmsReflectionWrapper
 ) : NmsWrapper {
-    private val getXFunction = reflectionWrapper.getFunction(targetClass, "getX", Version.V_15.handleFunction("b"))
-    private val getYFunction = reflectionWrapper.getFunction(targetClass, "getY", Version.V_15.handleFunction("c"))
-    private val getZFunction = reflectionWrapper.getFunction(targetClass, "getZ", Version.V_15.handleFunction("d"))
+
+    private val getXFunction = reflectionWrapper.getFunction(targetClass, "getX",
+        Version.V_17.handleFunction("b"),
+        Version.V_20_FORGE.handleFunction("m_123156_")
+    )
+
+    private val getYFunction = reflectionWrapper.getFunction(targetClass, "getY",
+        Version.V_17.handleFunction("c"),
+        Version.V_20_FORGE.handleFunction("m_123157_")
+    )
+
+    private val getZFunction = reflectionWrapper.getFunction(targetClass, "getZ",
+        Version.V_17.handleFunction("d"),
+        Version.V_20_FORGE.handleFunction("m_123158_")
+    )
 
     fun getX(): Float = getXFunction.call(vector3f) as Float
     fun getY(): Float = getYFunction.call(vector3f) as Float

--- a/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/reflect/NmsReflectionWrapperImpl.kt
+++ b/modules/bukkit-nms/src/main/kotlin/kr/hqservice/framework/nms/wrapper/reflect/NmsReflectionWrapperImpl.kt
@@ -89,7 +89,7 @@ class NmsReflectionWrapperImpl(
             getNmsClass(handlers.filter {
                 if (forgeSupport) it.getVersion().name.endsWith("_FORGE")
                 else !it.getVersion().name.endsWith("_FORGE")
-            }.sortedByDescending { it.getVersion().ordinal }
+            }.ifEmpty { handlers.toList() }.sortedByDescending { it.getVersion().ordinal }
                 .firstOrNull { it.getVersion().support(version, minorVersion) }?.apply {
                     name = if (isChangedName()) "" else ".$name"
                 }?.getName()?.run { "$this$name" }
@@ -187,7 +187,7 @@ class NmsReflectionWrapperImpl(
         val type = handlers.filter {
             if (forgeSupport) it.getVersion().name.endsWith("_FORGE")
             else !it.getVersion().name.endsWith("_FORGE")
-        }.sortedByDescending { it.getVersion().ordinal }
+        }.ifEmpty { handlers.toList() }.sortedByDescending { it.getVersion().ordinal }
             .firstOrNull { it.getVersion().support(version, minorVersion) }?.getName() ?: fieldName
         return clazz.memberProperties.firstOrNull {
             it.name == type
@@ -203,7 +203,7 @@ class NmsReflectionWrapperImpl(
             .filter {
                 if (forgeSupport) it.getVersion().name.endsWith("_FORGE")
                 else !it.getVersion().name.endsWith("_FORGE")
-            }.sortedByDescending { it.getVersion().ordinal }
+            }.ifEmpty { handlers.toList() }.sortedByDescending { it.getVersion().ordinal }
             .firstOrNull { it.getVersion().support(version, minorVersion) }?.getName() ?: staticFieldName
         return clazz.staticProperties.firstOrNull {
             it.name == type
@@ -222,7 +222,7 @@ class NmsReflectionWrapperImpl(
             val type = handlers.filter {
                 if (forgeSupport) it.getVersion().name.endsWith("_FORGE")
                 else !it.getVersion().name.endsWith("_FORGE")
-            }.filter { it.getVersion().support(version, minorVersion) }
+            }.ifEmpty { handlers.toList() }.filter { it.getVersion().support(version, minorVersion) }
                 .run {
                     if (isEmpty()) null
                     else maxBy { it.getVersion().ordinal }


### PR DESCRIPTION
대부분의 포지 핸들러는 1.17.1에 추가되었고, 테스트는 1.19.4 아크라이트(모드버킷) / 1.20.1, 1.20.2 페이퍼버킷 에서 진행됐습니다

ItemStack의 nms tag 추가/제거, VirtualArmorStand, VirtualWorldBorder, HQUpgrade 플러그인 등등 작동을 확인했습니다.

![image](https://github.com/HQService/HQFramework/assets/100404990/dc31ed8f-824a-4f68-a388-ce7e98038f73)